### PR TITLE
Remove androix.core dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ android-library = { id = "com.android.library", version.ref = "androidGradlePlug
 maven-publish = { id = "com.vanniktech.maven.publish", version = "0.34.0" }
 
 [libraries]
-androidx-core = { group = "androidx.core", name = "core", version = "1.17.0" }
 androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version = "1.4.0" }
 androidx-viewpager2 = { group = "androidx.viewpager2", name = "viewpager2", version = "1.1.0" }
 

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -39,7 +39,6 @@ dependencies {
     implementation(project(":simplecarousel"))
     implementation(project(":simplecarousel-pager"))
 
-    implementation(libs.androidx.core)
     implementation(libs.androidx.appcompat)
     implementation(libs.android.material)
     implementation(libs.androidx.activity)

--- a/simplecarousel-pager/build.gradle.kts
+++ b/simplecarousel-pager/build.gradle.kts
@@ -24,7 +24,6 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.core)
     api(libs.androidx.recyclerview)
     api(libs.androidx.viewpager2)
     api(project(":simplecarousel"))

--- a/simplecarousel/build.gradle.kts
+++ b/simplecarousel/build.gradle.kts
@@ -23,7 +23,6 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.core)
     api(libs.androidx.recyclerview)
 }
 


### PR DESCRIPTION
This library has no necessary to use androidx.core library explicitly. And also it forces to set target sdk to library user.