### PR TITLE
Fix isPartiallyVisible was returns false when child is larger than parent

### DIFF
--- a/simplecarousel/src/main/java/com/cheonjaeung/simplecarousel/android/ViewBoundsHelper.kt
+++ b/simplecarousel/src/main/java/com/cheonjaeung/simplecarousel/android/ViewBoundsHelper.kt
@@ -95,8 +95,7 @@ class ViewBoundsHelper(private val parentInfoCallback: ParentInfoCallback) {
         parentStart: Int,
         parentEnd: Int
     ): Boolean {
-        if (childEnd < parentStart || childStart > parentEnd) return false
-        return childStart > parentStart || childEnd < parentEnd
+        return childEnd > parentStart && childStart < parentEnd
     }
 
     private fun isCompletelyVisible(


### PR DESCRIPTION
If the child view is larger then parent container and child's start and end is out of bounds, The ViewBoundsHelper.isPartiallyVisible was returns false. It is incorrect. In this situation, the function should return true because event if child view start and end is invisible, the child view is partially visible.
This commit fix this bug.